### PR TITLE
better way to register a handler class

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ class DummyTask
     end
   end
 
+  # this is critical - if the handler factory does not register your task handler
+  # the Tasker system will not know how to either validate a request
+  # or ultimately handle the steps
+  register_handler(TASK_REGISTRY_NAME)
+
   # this makes it easier to define step templates for a handler
   # you could alternatively create an instance method `step_templates`
   # that returns an array of Tasker::StepTemplate's
@@ -135,11 +140,6 @@ class DummyTask
     @schema ||= { type: :object, required: [:dummy], properties: { dummy: { type: 'boolean' } } }
   end
 end
-
-# this is critical - if the handler factory does not register your task handler
-# the Tasker system will not know how to either validate a request
-# or ultimately handle the steps
-Tasker::HandlerFactory.instance.register(DummyTask::TASK_REGISTRY_NAME, DummyTask)
 
 ```
 ## Dependencies

--- a/app/models/tasker/task_handler.rb
+++ b/app/models/tasker/task_handler.rb
@@ -51,6 +51,10 @@ module Tasker
           definer.step_templates
         end
       end
+
+      def register_handler(name)
+        Tasker::HandlerFactory.instance.register(name, self)
+      end
     end
 
     def initialize

--- a/spec/mocks/dummy_task.rb
+++ b/spec/mocks/dummy_task.rb
@@ -28,6 +28,11 @@ class DummyTask
     end
   end
 
+  # this is critical - if the handler factory does not register your task handler
+  # the Tasker system will not know how to either validate a request
+  # or ultimately handle the steps
+  register_handler(TASK_REGISTRY_NAME)
+
   # this makes it easier to define step templates for a handler
   # you could alternatively create an instance method `step_templates`
   # that returns an array of Tasker::StepTemplate's
@@ -89,8 +94,3 @@ class DummyTask
     end
   end
 end
-
-# this is critical - if the handler factory does not register your task handler
-# the Tasker system will not know how to either validate a request
-# or ultimately handle the steps
-Tasker::HandlerFactory.instance.register(DummyTask::TASK_REGISTRY_NAME, DummyTask)


### PR DESCRIPTION
added another helper class method to allow registering the TaskHandler class by name during the class construction.